### PR TITLE
add/fix occurrences

### DIFF
--- a/src/accountTransactionInput.js
+++ b/src/accountTransactionInput.js
@@ -1,0 +1,198 @@
+import React from 'react';
+import { Formik, Field } from 'formik';
+
+class AccountTransactionInput extends React.Component {
+  constructor() {
+    super();
+    this.state = { visible: true };
+  }
+
+  toggleAccountTransactionVisibility() {
+    this.setState((prevState, props) => ({ visible: !prevState.visible }));
+  }
+
+  render() {
+    const { accounts } = this.props;
+    return this.state.visible ? (
+      <div className="box">
+        <h1 className="title has-text-centered">Add Debt Payback</h1>
+        <Formik
+          initialValues={this.props.initialValues}
+          onSubmit={(values, actions) => {
+            this.props.addAccountTransaction(values);
+            actions.setSubmitting(false);
+            actions.resetForm();
+          }}
+          render={({
+            values,
+            errors,
+            touched,
+            handleChange,
+            handleBlur,
+            handleSubmit,
+            isSubmitting
+          }) => (
+            <form onSubmit={handleSubmit} autoComplete="off">
+              <Field
+                type="text"
+                name="id"
+                className="input"
+                style={{ display: 'none' }}
+              />
+              <div className="field is-horizontal">
+                <div className="field-label is-normal">
+                  <label className="label">debt account</label>
+                </div>
+                <div className="field-body">
+                  <div className="field">
+                    <div className="control">
+                      <div className="select">
+                        <Field component="select" name="debtAccount">
+                          {accounts.map(account => (
+                            <option key={account.name} value={account.name}>
+                              {account.name}
+                            </option>
+                          ))}
+                        </Field>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                {touched.debtAccount &&
+                  errors.debtAccount && <div>{errors.debtAccount}</div>}
+              </div>
+              <div className="field is-horizontal">
+                <div className="field-label is-normal">
+                  <label className="label">account</label>
+                </div>
+                <div className="field-body">
+                  <div className="field">
+                    <div className="control">
+                      <div className="select">
+                        <Field component="select" name="raccount">
+                          {accounts.map(account => (
+                            <option key={account.name} value={account.name}>
+                              {account.name}
+                            </option>
+                          ))}
+                        </Field>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                {touched.raccount &&
+                  errors.raccount && <div>{errors.raccount}</div>}
+              </div>
+              <div className="field is-horizontal">
+                <div className="field-label is-normal">
+                  <label className="label">start</label>
+                </div>
+                <div className="field-body">
+                  <div className="field">
+                    <p className="control">
+                      <Field type="text" name="start" className="input" />
+                    </p>
+                  </div>
+                </div>
+                {touched.start && errors.start && <div>{errors.start}</div>}
+              </div>
+              <div className="field is-horizontal">
+                <div className="field-label is-normal">
+                  <label className="label">occurences</label>
+                </div>
+                <div className="field-body">
+                  <div className="field">
+                    <p className="control">
+                      <Field
+                        type="number"
+                        name="occurences"
+                        className="input"
+                      />
+                    </p>
+                  </div>
+                </div>
+                {touched.occurences &&
+                  errors.occurences && <div>{errors.occurences}</div>}
+              </div>
+              <div className="field is-horizontal">
+                <div className="field-label is-normal">
+                  <label className="label">rtype</label>
+                </div>
+                <div className="field-body">
+                  <div className="field">
+                    <div className="select">
+                      <Field component="select" name="rtype">
+                        <option value="none">No Repeating</option>
+                        <option value="day">
+                          Repeat Daily (or Every X Day)
+                        </option>
+                        <option value="day of week">
+                          Repeat on a Day of the Week
+                        </option>
+                        <option value="day of month">
+                          Repeat on a Day of the Month
+                        </option>
+                        <option value="bimonthly">
+                          Repeat Every Other Month on Day
+                        </option>
+                        <option value="quarterly">
+                          Repeat Every Quarter on Day
+                        </option>
+                        <option value="semiannually">
+                          Repeat Twice a Year on Day
+                        </option>
+                        <option value="annually">
+                          Repeat Every Year on Day
+                        </option>
+                      </Field>
+                    </div>
+                  </div>
+                </div>
+                {touched.rtype && errors.rtype && <div>{errors.rtype}</div>}
+              </div>
+              <div className="field is-horizontal">
+                <div className="field-label is-normal">
+                  <label className="label">cycle</label>
+                </div>
+                <div className="field-body">
+                  <div className="field">
+                    <p className="control">
+                      <Field type="number" name="cycle" className="input" />
+                    </p>
+                  </div>
+                </div>
+                {touched.cycle && errors.cycle && <div>{errors.cycle}</div>}
+              </div>
+              <div className="field is-horizontal">
+                <div className="field-label is-normal">
+                  <label className="label">value</label>
+                </div>
+                <div className="field-body">
+                  <div className="field">
+                    <p className="control">
+                      <Field type="number" name="value" className="input" />
+                    </p>
+                  </div>
+                </div>
+                {touched.value && errors.value && <div>{errors.value}</div>}
+              </div>
+              <div className="field is-grouped is-grouped-centered">
+                <div className="control">
+                  <button
+                    className="button is-link"
+                    type="submit"
+                    disabled={isSubmitting}
+                  >
+                    Add Transaction
+                  </button>
+                </div>
+              </div>
+            </form>
+          )}
+        />
+      </div>
+    ) : null;
+  }
+}
+
+export default AccountTransactionInput;

--- a/src/financial.js
+++ b/src/financial.js
@@ -5,6 +5,7 @@ import makeUUID from './makeUUID.js';
 
 import TransactionInput from './transactionInput';
 import AccountInput from './accountInput';
+import AccountTransactionInput from './accountTransactionInput';
 import YNABInput from './ynabInput.js';
 
 import fileDownload from 'js-file-download';
@@ -253,6 +254,26 @@ class Financial extends React.Component {
     this.setState(resolveData(newState));
   };
 
+  addAccountTransaction = result => {
+    console.log(result);
+    let newState = { ...this.state };
+    if (result.id || result.id !== '') {
+      let existingTransactionIndex = newState.accounts.payback
+        .map(t => t.id)
+        .indexOf(result.id);
+      if (existingTransactionIndex === -1) {
+        newState.transactions.push(result);
+      } else {
+        newState.transactions.splice(existingTransactionIndex, 1, result);
+      }
+    } else {
+      newState.transactions.push({ ...result, id: makeUUID() });
+    }
+    newState.transactionForm.id = '';
+    this.setState(resolveData(newState));
+    this.transactionTabs.tabClick(0);
+  };
+
   addYNAB = (tokens, resultantAccounts, resultantTransactions) => {
     let newState = { ...this.state };
     let indexed = {};
@@ -285,6 +306,7 @@ class Financial extends React.Component {
   };
 
   render() {
+    console.log(this);
     return (
       <React.Fragment>
         <section className="section">
@@ -378,10 +400,18 @@ class Financial extends React.Component {
                 addAccount={this.addAccount}
                 initialValues={this.state.accountForm}
               />,
-              debtTable(this.state.accounts, {
-                modifyAccount: this.modifyAccount,
-                deleteAccount: this.deleteAccount
-              })
+              <React.Fragment>
+                {debtTable(this.state.accounts, {
+                  modifyAccount: this.modifyAccount,
+                  deleteAccount: this.deleteAccount
+                })}
+                <AccountTransactionInput
+                  ref={ref => (this.AccountTransactionForm = ref)}
+                  accounts={this.state.accounts}
+                  addAccountTransaction={this.addAccountTransaction}
+                  initialValues={this.state.transactionForm}
+                />
+              </React.Fragment>
             ]}
           />
         </section>
@@ -511,6 +541,12 @@ const debtTable = (data, actions) =>
         {account.payback ? paybackTable(account.payback, actions) : null}
       </div>
       <div className="media-right">
+        <button
+          className="button is-rounded is-small is-success"
+          onClick={actions.toggleAccountTransactionVisibility}
+        >
+          +
+        </button>
         <button
           className="button is-rounded is-small is-info"
           onClick={actions.modifyAccount.bind(this, account.name)}

--- a/src/financial.js
+++ b/src/financial.js
@@ -30,9 +30,10 @@ class Financial extends React.Component {
       id: `oasis2`,
       raccount: `account`,
       description: `description`,
-      category: `test default`,
+      category: `test default occurences`,
       type: `income`,
-      start: `2018-03-22`,
+      start: `2018-09-22`,
+      occurences: 7,
       rtype: `day`,
       cycle: 1,
       value: 100

--- a/src/financial.js
+++ b/src/financial.js
@@ -135,7 +135,6 @@ class Financial extends React.Component {
               },
               {
                 raccount: 'account',
-                type: 'expense',
                 start: `2018-03-22`,
                 rtype: `day`,
                 cycle: 3,
@@ -161,6 +160,16 @@ class Financial extends React.Component {
         starting: 1000,
         interest: 0.0,
         vehicle: 'operating'
+      },
+      accountTransactionForm: {
+        id: ``,
+        debtAccount: `account`,
+        raccount: `account`,
+        start: `2018-03-22`,
+        rtype: `day`,
+        cycle: 3,
+        occurences: 0,
+        value: 150
       }
     };
 
@@ -255,23 +264,25 @@ class Financial extends React.Component {
   };
 
   addAccountTransaction = result => {
-    console.log(result);
     let newState = { ...this.state };
-    if (result.id || result.id !== '') {
-      let existingTransactionIndex = newState.accounts.payback
-        .map(t => t.id)
-        .indexOf(result.id);
-      if (existingTransactionIndex === -1) {
-        newState.transactions.push(result);
-      } else {
-        newState.transactions.splice(existingTransactionIndex, 1, result);
-      }
-    } else {
-      newState.transactions.push({ ...result, id: makeUUID() });
+    let accountIndex = newState.accounts
+      .map(a => a.name)
+      .indexOf(result.debtAccount);
+    let payback = { ...newState.accounts[accountIndex].payback };
+    payback.id = makeUUID();
+    if (!payback.transactions) {
+      payback.transactions = [];
     }
-    newState.transactionForm.id = '';
+    payback.transactions.push({
+      raccount: result.raccount,
+      start: result.start,
+      rtype: result.rtype,
+      cycle: result.cycle,
+      occurences: result.occurences,
+      value: result.value
+    });
+    newState.accountTransactionForm.id = '';
     this.setState(resolveData(newState));
-    this.transactionTabs.tabClick(0);
   };
 
   addYNAB = (tokens, resultantAccounts, resultantTransactions) => {
@@ -306,7 +317,6 @@ class Financial extends React.Component {
   };
 
   render() {
-    console.log(this);
     return (
       <React.Fragment>
         <section className="section">
@@ -409,7 +419,7 @@ class Financial extends React.Component {
                   ref={ref => (this.AccountTransactionForm = ref)}
                   accounts={this.state.accounts}
                   addAccountTransaction={this.addAccountTransaction}
-                  initialValues={this.state.transactionForm}
+                  initialValues={this.state.accountTransactionForm}
                 />
               </React.Fragment>
             ]}

--- a/src/resolveFinancials/index.js
+++ b/src/resolveFinancials/index.js
@@ -7,7 +7,7 @@ import startOfDay from 'date-fns/fp/startOfDay';
 import computeTransactionModifications from './resolveTransactions.js';
 
 const resolveData = data => {
-  let graphRange = { start: past(), end: future(365) };
+  let graphRange = { start: past(), end: future(30) };
   return resolveDataAtDateRange(data, graphRange);
 };
 

--- a/src/resolveFinancials/resolveTransactions.js
+++ b/src/resolveFinancials/resolveTransactions.js
@@ -63,12 +63,16 @@ const generateModification = (
   let modification = nextModification(transaction.rtype)(transaction, prevDate);
   modification.mutateKey = transaction.id;
 
+  let hasNotHitNumberOfOccurences =
+    (!!transaction && !transaction.occurences) ||
+    occurrences <= transaction.occurences;
+
   // if this is a modification we should use then add it to the list
   // and generate the next one
   if (
     isWithinInterval(transactionInterval)(modification.date) &&
     isAfter(prevDate)(modification.date) &&
-    (!transaction.occurrences || occurrences < transaction.occurrences) &&
+    hasNotHitNumberOfOccurences &&
     occurrences < 365
   ) {
     modifications.push(modification);

--- a/src/transactionInput.js
+++ b/src/transactionInput.js
@@ -115,6 +115,24 @@ class TransactionInput extends React.Component {
               </div>
               <div className="field is-horizontal">
                 <div className="field-label is-normal">
+                  <label className="label">occurences</label>
+                </div>
+                <div className="field-body">
+                  <div className="field">
+                    <p className="control">
+                      <Field
+                        type="number"
+                        name="occurences"
+                        className="input"
+                      />
+                    </p>
+                  </div>
+                </div>
+                {touched.occurences &&
+                  errors.occurences && <div>{errors.occurences}</div>}
+              </div>
+              <div className="field is-horizontal">
+                <div className="field-label is-normal">
                   <label className="label">rtype</label>
                 </div>
                 <div className="field-body">


### PR DESCRIPTION
This adds (and fixes existing) code to allow transactions to end after X occurrences. This is the number of occurrences to appear in the future. We may also look to support the number of occurrences after the start date. For example, entering a `4` will always show 4 instances regardless of the start day. However, you may only have "4 equal payments" on a transaction beginning on Y date.